### PR TITLE
update urls for 3 datasets

### DIFF
--- a/recipes/dpr_parksproperties/build.py
+++ b/recipes/dpr_parksproperties/build.py
@@ -6,7 +6,7 @@ csv.field_size_limit(sys.maxsize)
 
 def ETL():
     table_name = 'dpr_parksproperties'
-    url = 'https://data.cityofnewyork.us/api/views/9mej-zh79/rows.csv?accessType=DOWNLOAD'
+    url = 'https://data.cityofnewyork.us/api/views/e5x7-d2uz/rows.csv?accessType=DOWNLOAD'
 
     base_path = create_base_path(__file__)
 

--- a/recipes/usdot_ports/build.py
+++ b/recipes/usdot_ports/build.py
@@ -43,7 +43,7 @@ def ETL(table_name):
     ).process()
 
 if __name__ == '__main__':
-    url = 'https://opendata.arcgis.com/datasets/490e1e06b54b4a5bb1e58523a5d546a7_0.zip'
+    url = 'https://opendata.arcgis.com/datasets/93f52f638bb948de9e0f5b1b578bdfaa_0.zip'
     table_name = 'usdot_ports'
 
     unzip(url)

--- a/recipes/usnps_parks/build.py
+++ b/recipes/usnps_parks/build.py
@@ -8,7 +8,7 @@ import csv
 csv.field_size_limit(sys.maxsize)
 
 def download_unzip(): 
-    url = 'https://irma.nps.gov/DataStore/DownloadFile/621132'
+    url = 'https://irma.nps.gov/DataStore/DownloadFile/627620'
     path = Path(__file__).parent/'nps_boundry.zip'
     target = Path(__file__).parent/'nps_boundry'
     os.system(f'curl -o {path} {url}')


### PR DESCRIPTION
The source URLs for the following 3 datasets changed, update their URLs in data recipes
- dpr_parksproperties: https://data.cityofnewyork.us/api/views/e5x7-d2uz/rows.csv?accessType=DOWNLOAD
- usdot_ports: https://opendata.arcgis.com/datasets/93f52f638bb948de9e0f5b1b578bdfaa_0.zip
- usnps_parks: https://irma.nps.gov/DataStore/DownloadFile/627620
